### PR TITLE
feat: 환불 및 포인트/멤버십 복구 구현

### DIFF
--- a/src/main/java/com/bootcamp/paymentdemo/common/Constants.java
+++ b/src/main/java/com/bootcamp/paymentdemo/common/Constants.java
@@ -8,6 +8,10 @@ public class Constants {
     public static final String ADMIN_SESSION_NAME = "loginAdmin";
     //region 도메인 오류 메세지
     public static final String MSG_NOT_FOUND_MEMBER = "회원을 찾을 수 없습니다";
+    // 환불 관련 오류 메시지
+    public static final String MSG_NOT_FOUND_PAYMENT = "존재하지 않는 결제 정보입니다";
+    public static final String MSG_ALREADY_REFUNDED = "이미 환불 처리된 결제입니다";
+    public static final String MSG_INVALID_REFUND_STATUS = "환불 가능한 결제 상태가 아닙니다";
     //endregion 도메인 오류 메세지
 
     //region 서버 오류 메세지

--- a/src/main/java/com/bootcamp/paymentdemo/common/config/SecurityConfig.java
+++ b/src/main/java/com/bootcamp/paymentdemo/common/config/SecurityConfig.java
@@ -65,6 +65,9 @@ public class SecurityConfig {
                     // 4) 인증 API
                     .requestMatchers(HttpMethod.POST, "/api/auth/login", "/api/signup").permitAll()
 
+                    // 웹훅
+                    .requestMatchers("/api/webhooks/**").permitAll()
+
                     // 5) 그 외 API는 인증 필요
                     .requestMatchers("/api/**").authenticated()
 

--- a/src/main/java/com/bootcamp/paymentdemo/common/exception/ErrorEnum.java
+++ b/src/main/java/com/bootcamp/paymentdemo/common/exception/ErrorEnum.java
@@ -3,12 +3,16 @@ package com.bootcamp.paymentdemo.common.exception;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
-import static com.bootcamp.paymentdemo.common.Constants.MSG_DUPLICATE_EMAIL;
-import static com.bootcamp.paymentdemo.common.Constants.MSG_NOT_FOUND_MEMBER;
+import static com.bootcamp.paymentdemo.common.Constants.*;
 
 @Getter
 public enum ErrorEnum {
     ERR_NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, MSG_NOT_FOUND_MEMBER),
+
+    // 환불 관련
+    ERR_NOT_FOUND_PAYMENT(HttpStatus.NOT_FOUND, MSG_NOT_FOUND_PAYMENT),
+    ERR_ALREADY_REFUNDED(HttpStatus.BAD_REQUEST, MSG_ALREADY_REFUNDED),
+    ERR_INVALID_REFUND_STATUS(HttpStatus.BAD_REQUEST, MSG_INVALID_REFUND_STATUS),
 
     // member exception
     ERR_DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, MSG_DUPLICATE_EMAIL);

--- a/src/main/java/com/bootcamp/paymentdemo/domain/member/entity/Member.java
+++ b/src/main/java/com/bootcamp/paymentdemo/domain/member/entity/Member.java
@@ -55,7 +55,7 @@ public class Member extends Base {
     @Column(nullable = false)
     private boolean deleted;
 
-    private LocalDateTime deletedAt;
+    private LocalDateTime deleted_at;
 
     private String refreshToken;
 
@@ -73,5 +73,42 @@ public class Member extends Base {
         member.totalPriceAmount = 0;
         member.deleted = false;
         return member;
+    }
+
+    public void addPoint(Integer amount) {
+        this.point += amount;
+    }
+
+    public void minusPoint(Integer amount) {
+        this.point -= amount;
+    }
+
+    public void addTotalPriceAmount(Integer amount) {
+        if (amount == null || amount < 0) return;
+
+        if (this.totalPriceAmount == null) {
+            this.totalPriceAmount = 0;
+        }
+        this.totalPriceAmount += amount;
+    }
+
+    public void subtractTotalPriceAmount(Integer amount) {
+        if (amount == null || amount < 0) return;
+
+        if (this.totalPriceAmount == null) {
+            this.totalPriceAmount = 0;
+        }
+
+        // 누적 금액이 차감액보다 적으면 0으로 초기화 (음수 방지)
+        if (this.totalPriceAmount >= amount) {
+            this.totalPriceAmount -= amount;
+        } else {
+            this.totalPriceAmount = 0;
+        }
+    }
+
+    public void updateGrade(Grade grade) {
+        this.grade = grade;
+        this.gradeAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/bootcamp/paymentdemo/domain/member/entity/Member.java
+++ b/src/main/java/com/bootcamp/paymentdemo/domain/member/entity/Member.java
@@ -55,7 +55,7 @@ public class Member extends Base {
     @Column(nullable = false)
     private boolean deleted;
 
-    private LocalDateTime deleted_at;
+    private LocalDateTime deletedAt;
 
     private String refreshToken;
 

--- a/src/main/java/com/bootcamp/paymentdemo/domain/order/entity/Order.java
+++ b/src/main/java/com/bootcamp/paymentdemo/domain/order/entity/Order.java
@@ -1,6 +1,7 @@
 package com.bootcamp.paymentdemo.domain.order.entity;
 
 import com.bootcamp.paymentdemo.common.entity.Base;
+import com.bootcamp.paymentdemo.domain.member.entity.Member;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -16,6 +17,10 @@ public class Order extends Base {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long orderId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
 
     @Column(nullable = false)
     private String orderNo;
@@ -43,6 +48,7 @@ public class Order extends Base {
     private LocalDateTime deletedAt;
 
     public static Order register(
+            Member member,
             String orderNo,
             Integer totalPrice,
             Integer price,
@@ -52,7 +58,7 @@ public class Order extends Base {
             LocalDateTime orderAt
     ) {
         Order order = new Order();
-
+        order.member = member;
         order.orderNo = orderNo;
         order.totalPrice = totalPrice;
         order.price = price;
@@ -64,6 +70,14 @@ public class Order extends Base {
         order.deletedAt = null;
 
         return order;
+    }
+
+    public void updateStatus(OrderStatus status) {
+        this.status = status;
+        if(status == OrderStatus.REFUNDED) {
+            this.deleted = true;
+            this.deletedAt = LocalDateTime.now();
+        }
     }
 
 }

--- a/src/main/java/com/bootcamp/paymentdemo/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/bootcamp/paymentdemo/domain/order/repository/OrderRepository.java
@@ -1,0 +1,9 @@
+package com.bootcamp.paymentdemo.domain.order.repository;
+
+import com.bootcamp.paymentdemo.domain.order.entity.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderRepository extends JpaRepository<Order, Integer> {
+
+
+}

--- a/src/main/java/com/bootcamp/paymentdemo/domain/payment/entity/Payment.java
+++ b/src/main/java/com/bootcamp/paymentdemo/domain/payment/entity/Payment.java
@@ -71,4 +71,11 @@ public class Payment extends Base {
         deleted = false;
         deletedAt = null;
     }
+
+    public void updateStatus(PaymentStatus status) {
+        this.status = status;
+        if (status == PaymentStatus.REFUNDED) {
+            this.refundAt = LocalDateTime.now();
+        }
+    }
 }

--- a/src/main/java/com/bootcamp/paymentdemo/domain/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/bootcamp/paymentdemo/domain/payment/repository/PaymentRepository.java
@@ -1,0 +1,11 @@
+package com.bootcamp.paymentdemo.domain.payment.repository;
+
+import com.bootcamp.paymentdemo.domain.payment.entity.Payment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PaymentRepository extends JpaRepository<Payment, Long> {
+
+    Optional<Payment> findByPortOneId(String portOneId);
+}

--- a/src/main/java/com/bootcamp/paymentdemo/domain/point/entity/MemberPointLog.java
+++ b/src/main/java/com/bootcamp/paymentdemo/domain/point/entity/MemberPointLog.java
@@ -16,7 +16,7 @@ public class MemberPointLog {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long point_log_id;
+    private Long pointLogId;
 
     @Column(nullable = false, length = 100)
     private String orderNo;
@@ -25,10 +25,10 @@ public class MemberPointLog {
     private Integer point;
 
     @Column(nullable = false)
-    private LocalDateTime save_at;
+    private LocalDateTime saveAt;
 
     @Column(nullable = false)
-    private LocalDateTime expire_at;
+    private LocalDateTime expireAt;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "status", length = 20, nullable = false)
@@ -44,8 +44,8 @@ public class MemberPointLog {
         log.point = point;
         log.status = status;
         log.member = member;
-        log.save_at = LocalDateTime.now();
-        log.expire_at = LocalDateTime.now().plusYears(1);
+        log.saveAt = LocalDateTime.now();
+        log.expireAt = LocalDateTime.now().plusYears(1);
         return log;
     }
 }

--- a/src/main/java/com/bootcamp/paymentdemo/domain/point/entity/MemberPointLog.java
+++ b/src/main/java/com/bootcamp/paymentdemo/domain/point/entity/MemberPointLog.java
@@ -30,11 +30,22 @@ public class MemberPointLog {
     @Column(nullable = false)
     private LocalDateTime expire_at;
 
-    @Column(nullable = false)
     @Enumerated(EnumType.STRING)
+    @Column(name = "status", length = 20, nullable = false)
     private MemberPointLogStatus status;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
+
+    public static MemberPointLog create(String OrderNo, Integer point, MemberPointLogStatus status, Member member) {
+        MemberPointLog log = new MemberPointLog();
+        log.orderNo = OrderNo;
+        log.point = point;
+        log.status = status;
+        log.member = member;
+        log.save_at = LocalDateTime.now();
+        log.expire_at = LocalDateTime.now().plusYears(1);
+        return log;
+    }
 }

--- a/src/main/java/com/bootcamp/paymentdemo/domain/point/entity/MemberPointLogStatus.java
+++ b/src/main/java/com/bootcamp/paymentdemo/domain/point/entity/MemberPointLogStatus.java
@@ -2,5 +2,7 @@ package com.bootcamp.paymentdemo.domain.point.entity;
 
 public enum MemberPointLogStatus {
     SAVE,
-    USE
+    USE,
+    RECOVER,
+    CANCEL_EARN
 }

--- a/src/main/java/com/bootcamp/paymentdemo/domain/point/repository/MemberPointLogRepository.java
+++ b/src/main/java/com/bootcamp/paymentdemo/domain/point/repository/MemberPointLogRepository.java
@@ -1,0 +1,9 @@
+package com.bootcamp.paymentdemo.domain.point.repository;
+
+import com.bootcamp.paymentdemo.domain.point.entity.MemberPointLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberPointLogRepository extends JpaRepository<MemberPointLog, Long> {
+
+
+}

--- a/src/main/java/com/bootcamp/paymentdemo/domain/refund/repository/RefundRepository.java
+++ b/src/main/java/com/bootcamp/paymentdemo/domain/refund/repository/RefundRepository.java
@@ -1,0 +1,10 @@
+package com.bootcamp.paymentdemo.domain.refund.repository;
+
+import com.bootcamp.paymentdemo.domain.refund.entity.Refund;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RefundRepository extends JpaRepository<Refund, Long> {
+
+    // 멱등성 체크
+    boolean existsByPayment_PaymentId(Long paymentId);
+}

--- a/src/main/java/com/bootcamp/paymentdemo/domain/refund/service/RefundService.java
+++ b/src/main/java/com/bootcamp/paymentdemo/domain/refund/service/RefundService.java
@@ -1,0 +1,93 @@
+package com.bootcamp.paymentdemo.domain.refund.service;
+
+import com.bootcamp.paymentdemo.common.exception.ErrorEnum;
+import com.bootcamp.paymentdemo.common.exception.ServiceErrorException;
+
+import com.bootcamp.paymentdemo.domain.member.entity.Grade;
+import com.bootcamp.paymentdemo.domain.member.entity.Member;
+import com.bootcamp.paymentdemo.domain.order.repository.OrderRepository;
+import com.bootcamp.paymentdemo.domain.order.entity.Order;
+import com.bootcamp.paymentdemo.domain.order.entity.OrderStatus;
+import com.bootcamp.paymentdemo.domain.payment.entity.Payment;
+import com.bootcamp.paymentdemo.domain.payment.entity.PaymentStatus;
+import com.bootcamp.paymentdemo.domain.payment.repository.PaymentRepository;
+import com.bootcamp.paymentdemo.domain.point.entity.MemberPointLog;
+import com.bootcamp.paymentdemo.domain.point.entity.MemberPointLogStatus;
+import com.bootcamp.paymentdemo.domain.point.repository.MemberPointLogRepository;
+import com.bootcamp.paymentdemo.domain.refund.entity.Refund;
+import com.bootcamp.paymentdemo.domain.refund.entity.RefundStatus;
+import com.bootcamp.paymentdemo.domain.refund.repository.RefundRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class RefundService {
+
+    private final RefundRepository refundRepository;
+    private final PaymentRepository paymentRepository;
+    private final MemberPointLogRepository memberPointLogRepository;
+    private final OrderRepository orderRepository;
+
+    @Transactional
+    public void processRefund(String paymentId) {
+        Payment payment = paymentRepository.findByPortOneId(paymentId)
+                .orElseThrow(() -> new ServiceErrorException(ErrorEnum.ERR_NOT_FOUND_PAYMENT));
+        Order order = payment.getOrder();
+        Member member = order.getMember();
+
+        validateRefundAvailability(payment);
+
+        // 환불 기록 및 상태 변경
+        Refund refund = Refund.register(payment, payment.getPriceSnap(), RefundStatus.REFUNDED, "웹훅 취소");
+        refundRepository.save(refund);
+        payment.updateStatus(PaymentStatus.REFUNDED);
+        order.updateStatus(OrderStatus.REFUNDED);
+
+        // 누적 결제 금액 차감
+        member.subtractTotalPriceAmount(order.getPrice());
+
+        // 등급 재계산 호출
+        updateMemberGrade(member);
+
+        // 포인트 복구
+        if (order.getUsePoint() > 0) {
+            member.addPoint(order.getUsePoint());
+            memberPointLogRepository.save(MemberPointLog.create(order.getOrderNo(), order.getUsePoint(), MemberPointLogStatus.RECOVER, member));
+        }
+
+        // 적립 취소
+        if (order.getSavePoint() > 0) {
+            member.minusPoint(order.getSavePoint());
+            memberPointLogRepository.save(MemberPointLog.create(order.getOrderNo(), order.getSavePoint(), MemberPointLogStatus.CANCEL_EARN, member));
+        }
+    }
+
+    private void validateRefundAvailability(Payment payment) {
+        if (payment.getStatus() == PaymentStatus.REFUNDED) {
+            throw new ServiceErrorException(ErrorEnum.ERR_ALREADY_REFUNDED);
+        }
+
+        if (payment.getStatus() != PaymentStatus.COMPLETE) {
+            throw new ServiceErrorException(ErrorEnum.ERR_INVALID_REFUND_STATUS);
+        }
+    }
+
+    private void updateMemberGrade(Member member) {
+        Integer totalAmount = member.getTotalPriceAmount();
+        Grade newGrade;
+
+        if (totalAmount >= 300000) {
+            newGrade = Grade.DIAMOND;
+        } else if (totalAmount >= 200000) {
+            newGrade = Grade.GOLD;
+        } else if (totalAmount >= 100000) {
+            newGrade = Grade.SILVER;
+        } else {
+            newGrade = Grade.BRONZE;
+        }
+
+        member.updateGrade(newGrade);
+    }
+}

--- a/src/main/java/com/bootcamp/paymentdemo/domain/webhook/service/WebhookService.java
+++ b/src/main/java/com/bootcamp/paymentdemo/domain/webhook/service/WebhookService.java
@@ -1,5 +1,6 @@
 package com.bootcamp.paymentdemo.domain.webhook.service;
 
+import com.bootcamp.paymentdemo.domain.refund.service.RefundService;
 import com.bootcamp.paymentdemo.domain.webhook.dto.WebhookRequest;
 import com.bootcamp.paymentdemo.domain.webhook.entity.Webhook;
 import com.bootcamp.paymentdemo.domain.webhook.entity.WebhookStatus;
@@ -13,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class WebhookService {
 
     private final WebhookRepository webhookRepository;
+    private final RefundService refundService;
 
     @Transactional
     public void process(String recWebhookId, WebhookRequest request) {
@@ -33,12 +35,11 @@ public class WebhookService {
 
         // 임시 마커로 println 사용
         if ("CANCELLED".equals(request.getStatus())) {
-            System.out.println("환불 웹훅 수신: " + request.getPayment_id());
+            refundService.processRefund(request.getPayment_id());
         } else if ("PAID".equals(request.getStatus())) {
             System.out.println("결제 완료 웹훅 수신: " + request.getPayment_id());
         }
 
-        // 환불 로직이 완료되지 않아서 주석처리
-        // webhook.complete();
+        webhook.complete();
     }
 }


### PR DESCRIPTION
# Work History
* 환불 비즈니스 로직 구현
RefundService.processRefund를 통해 결제/주문 상태를 REFUNDED로 일괄 업데이트하는 로직 구현
* 사용자 포인트 정산 및 복구
결제 시 사용했던 포인트는 회수(RECOVER)하고, 결제로 인해 적립되었던 포인트는 취소(CANCEL_EARN) 처리
* 실시간 멤버십 등급 재조정
환불된 금액을 사용자의 총 결제 금액(total_price_amount)에서 차감한 후, 변경된 금액에 따라 등급(Grade)을 실시간으로 갱신
* 웹훅 보안 설정
SecurityConfig에서 웹훅 경로(/api/webhooks/**)에 대한 인증 예외(permitAll) 설정

# 테스트
1. SILVER → SILVER 유지 케이스
상황: 누적 15만 원(SILVER) 회원 → 5만 원 결제건 환불 (최종 10만 원)
결과: total_price_amount 10만 원으로 차감, 등급 SILVER 유지 확인

2. SILVER → BRONZE 강등 케이스
상황: 누적 12만 원(SILVER) 회원 → 5만 원 결제건 환불 (최종 7만 원)
결과: total_price_amount 7만 원으로 차감, 등급 BRONZE로 자동 강등 확인

3. 포인트 검증
상황: 결제 시 사용한 포인트 5,000점 / 적립된 포인트 1,500점인 건 환불
결과: members.point: 5,000점 복구 완료
member_point_logs: RECOVER(5,000), CANCEL_EARN(1,500) 상태로 이력 생성 완료

4. 멱등성 및 상태 업데이트 검증
상황 A: 동일한 webhook-id로 재전송
결과: 200 OK 응답 및 로직 조기 종료 (중복 처리 방지 및 포트원 재전송 차단)
<img width="955" height="463" alt="테스트" src="https://github.com/user-attachments/assets/85ae3666-1ad6-4228-9921-06371f3a4b4f" />

상황 B: 새로운 webhook-id로 이미 환불된 payment_id 요청
결과: 400 Bad Request 응답 및 "이미 환불 처리된 결제입니다" 메시지 반환 확인
<img width="954" height="542" alt="이미 환불 처리" src="https://github.com/user-attachments/assets/3d617822-02cc-4a0b-bfca-1fb1de7da82b" />

결론: 웹훅 레이어와 도메인 레이어에서 2중으로 멱등성을 보장하며, 어떠한 경우에도 중복 환불이나 포인트 복구가 발생하지 않음을 검증 완료

# Releated Issue
Closes #17 

# CheckList
- [x] Commit Convention 준수 여부 확인
- [x] 코드에 대해서 주석 작성 여부 확인
- [x] 불필요 주석, import, Test Log 삭제 여부 확인

# ETC
status 컬럼의 길이 문제로 발생했던 Data truncated 에러를 해결하기 위해 MemberPointLog 엔티티의 @Column(length = 20) 설정을 추가
현재 로컬 환경에서 Postman을 통한 시나리오 검증은 모두 마쳤으며, 추후 결제 완료(PAID) 로직이 합쳐지면 다시 테스트 예정