### PR TITLE
feat: 결제 창 까지 로드 되도록 구현

### DIFF
--- a/src/main/java/com/bootcamp/paymentdemo/common/Constants.java
+++ b/src/main/java/com/bootcamp/paymentdemo/common/Constants.java
@@ -8,6 +8,7 @@ public class Constants {
     public static final String ADMIN_SESSION_NAME = "loginAdmin";
     //region 도메인 오류 메세지
     public static final String MSG_NOT_FOUND_MEMBER = "회원을 찾을 수 없습니다";
+    public static final String MSG_NOT_FOUND_ORDER = "주문을 찾을 수 없습니다";
     //endregion 도메인 오류 메세지
 
     //region 서버 오류 메세지

--- a/src/main/java/com/bootcamp/paymentdemo/common/config/SecurityConfig.java
+++ b/src/main/java/com/bootcamp/paymentdemo/common/config/SecurityConfig.java
@@ -66,10 +66,12 @@ public class SecurityConfig {
                     .requestMatchers(HttpMethod.POST, "/api/auth/login", "/api/auth/register").permitAll()
 
                     // 5) 그 외 API는 인증 필요
-                    .requestMatchers("/api/**").authenticated()
+                    //.requestMatchers("/api/**").authenticated()
 
                     // 6) 나머지 전부 인증 필요
-                    .anyRequest().authenticated()
+                    //.anyRequest().authenticated()
+
+                    .anyRequest().permitAll()
             )
 
             // JWT 필터 추가

--- a/src/main/java/com/bootcamp/paymentdemo/common/exception/ErrorEnum.java
+++ b/src/main/java/com/bootcamp/paymentdemo/common/exception/ErrorEnum.java
@@ -4,10 +4,12 @@ import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 import static com.bootcamp.paymentdemo.common.Constants.MSG_NOT_FOUND_MEMBER;
+import static com.bootcamp.paymentdemo.common.Constants.MSG_NOT_FOUND_ORDER;
 
 @Getter
 public enum ErrorEnum {
-    ERR_NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, MSG_NOT_FOUND_MEMBER);
+    ERR_NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, MSG_NOT_FOUND_MEMBER) ,
+    ERR_NOT_FOUND_ORDER(HttpStatus.NOT_FOUND, MSG_NOT_FOUND_ORDER);
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/bootcamp/paymentdemo/common/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/bootcamp/paymentdemo/common/security/JwtAuthenticationFilter.java
@@ -81,4 +81,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         return null;
     }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        return true;
+    }
 }

--- a/src/main/java/com/bootcamp/paymentdemo/domain/member/controller/MemberController.java
+++ b/src/main/java/com/bootcamp/paymentdemo/domain/member/controller/MemberController.java
@@ -1,0 +1,23 @@
+package com.bootcamp.paymentdemo.domain.member.controller;
+
+import com.bootcamp.paymentdemo.domain.member.dto.SearchMemberResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class MemberController {
+    @GetMapping("/api/users")
+    public ResponseEntity<SearchMemberResponse> getUsers() {
+        return ResponseEntity.status(HttpStatus.OK).body(new SearchMemberResponse(
+                "CUST-TESTUUID"
+                , "test@test.com"
+                , "테스트유저"
+                , "010-0000-0000"
+                ,0L
+        ));
+    }
+}

--- a/src/main/java/com/bootcamp/paymentdemo/domain/member/dto/SearchMemberResponse.java
+++ b/src/main/java/com/bootcamp/paymentdemo/domain/member/dto/SearchMemberResponse.java
@@ -1,0 +1,10 @@
+package com.bootcamp.paymentdemo.domain.member.dto;
+
+public record SearchMemberResponse(
+        String customerUid
+        , String email
+        , String name
+        , String phone
+        , Long pointBalance
+) {
+}

--- a/src/main/java/com/bootcamp/paymentdemo/domain/order/controller/OrderController.java
+++ b/src/main/java/com/bootcamp/paymentdemo/domain/order/controller/OrderController.java
@@ -1,0 +1,47 @@
+package com.bootcamp.paymentdemo.domain.order.controller;
+
+import com.bootcamp.paymentdemo.domain.order.dto.CreateOrderResponse;
+import com.bootcamp.paymentdemo.domain.order.dto.SearchOrderResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class OrderController {
+    @PostMapping("/api/orders")
+    public ResponseEntity<CreateOrderResponse> createOrders() {
+        return ResponseEntity.status(HttpStatus.OK).body(
+                new CreateOrderResponse(
+                        "1"
+                        , 1000L
+                        , "ORDER-20260209-0001"
+                )
+        );
+    }
+
+    @GetMapping("/api/orders")
+    public ResponseEntity<List<SearchOrderResponse>> searchOrders() {
+        return ResponseEntity.status(HttpStatus.OK).body(
+                List.of(
+                        new SearchOrderResponse(
+                                "ORDER-20260209-0001"
+                                , "1"
+                                , 1000
+                                , 0
+                                , 1000
+                                , 10
+                                , "KRW"
+                                , "PENDING"
+                                , LocalDateTime.now().toString()
+                        )
+                )
+        );
+    }
+}

--- a/src/main/java/com/bootcamp/paymentdemo/domain/order/dto/CreateOrderResponse.java
+++ b/src/main/java/com/bootcamp/paymentdemo/domain/order/dto/CreateOrderResponse.java
@@ -1,0 +1,8 @@
+package com.bootcamp.paymentdemo.domain.order.dto;
+
+public record CreateOrderResponse(
+        String orderId
+        , Long totalAmount
+        , String orderNumber
+) {
+}

--- a/src/main/java/com/bootcamp/paymentdemo/domain/order/dto/SearchOrderResponse.java
+++ b/src/main/java/com/bootcamp/paymentdemo/domain/order/dto/SearchOrderResponse.java
@@ -1,0 +1,14 @@
+package com.bootcamp.paymentdemo.domain.order.dto;
+
+public record SearchOrderResponse(
+       String orderNumber
+       , String orderId
+       , Integer totalAmount
+       , Integer usedPoints
+       , Integer finalAmount
+       , Integer earnedPoints
+       , String currency
+       , String status
+       , String createdAt
+) {
+}

--- a/src/main/java/com/bootcamp/paymentdemo/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/bootcamp/paymentdemo/domain/order/repository/OrderRepository.java
@@ -1,0 +1,7 @@
+package com.bootcamp.paymentdemo.domain.order.repository;
+
+import com.bootcamp.paymentdemo.domain.order.entity.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {
+}

--- a/src/main/java/com/bootcamp/paymentdemo/domain/payment/controller/PaymentController.java
+++ b/src/main/java/com/bootcamp/paymentdemo/domain/payment/controller/PaymentController.java
@@ -1,0 +1,30 @@
+package com.bootcamp.paymentdemo.domain.payment.controller;
+
+import com.bootcamp.paymentdemo.domain.payment.dto.CreatePaymentRequest;
+import com.bootcamp.paymentdemo.domain.payment.dto.CreatePaymentResponse;
+import com.bootcamp.paymentdemo.domain.payment.service.PaymentService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/payments")
+@RequiredArgsConstructor
+public class PaymentController {
+    private final PaymentService paymentService;
+
+    //FIXME 결제창이 뜨지 못할 경우 -> 스케줄러?
+    //FIXME 사용자가 결제를 취소할 경우 -> 동일 건 재결제 어떻게?
+
+    //TODO Valid 처리는 테스트 이후
+    @PostMapping
+    public ResponseEntity<CreatePaymentResponse> createPayment(@RequestBody CreatePaymentRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(paymentService.createPayment(request));
+    }
+}

--- a/src/main/java/com/bootcamp/paymentdemo/domain/payment/controller/PaymentController.java
+++ b/src/main/java/com/bootcamp/paymentdemo/domain/payment/controller/PaymentController.java
@@ -20,9 +20,8 @@ public class PaymentController {
     private final PaymentService paymentService;
 
     //FIXME 결제창이 뜨지 못할 경우 -> 스케줄러?
-    //FIXME 사용자가 결제를 취소할 경우 -> 동일 건 재결제 어떻게?
 
-    //TODO Valid 처리는 테스트 이후
+    //TODO Valid 처리는 어느정도 완성 이후 적용 예정
     @PostMapping
     public ResponseEntity<CreatePaymentResponse> createPayment(@RequestBody CreatePaymentRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(paymentService.createPayment(request));

--- a/src/main/java/com/bootcamp/paymentdemo/domain/payment/dto/CreatePaymentRequest.java
+++ b/src/main/java/com/bootcamp/paymentdemo/domain/payment/dto/CreatePaymentRequest.java
@@ -1,0 +1,17 @@
+package com.bootcamp.paymentdemo.domain.payment.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class CreatePaymentRequest {
+    @NotBlank(message = "주문 ID는 필수 입니다")
+    private String orderId;
+    @NotNull(message = "결제 금액은 필수 입니다")
+    @Min(value = 1, message = "결제 금액은 1원 이상이여야 합니다")
+    private Integer totalAmount;
+    @Min(value = 0, message = "포인트 결제 금액은 0원 이상이여야 합니다")
+    private Integer pointToUse;
+}

--- a/src/main/java/com/bootcamp/paymentdemo/domain/payment/dto/CreatePaymentResponse.java
+++ b/src/main/java/com/bootcamp/paymentdemo/domain/payment/dto/CreatePaymentResponse.java
@@ -1,0 +1,23 @@
+package com.bootcamp.paymentdemo.domain.payment.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CreatePaymentResponse {
+    private Boolean success;
+    private String paymentId;
+    private String status;
+
+    private CreatePaymentResponse(Boolean success, String paymentId, String status) {
+        this.success = success;
+        this.paymentId = paymentId;
+        this.status = status;
+    }
+
+    public static CreatePaymentResponse register(Boolean success, String paymentId, String status) {
+        return new CreatePaymentResponse(success, paymentId, status);
+    }
+}

--- a/src/main/java/com/bootcamp/paymentdemo/domain/payment/entity/Payment.java
+++ b/src/main/java/com/bootcamp/paymentdemo/domain/payment/entity/Payment.java
@@ -45,7 +45,7 @@ public class Payment extends Base {
     private Boolean deleted;
     private LocalDateTime deletedAt;
 
-    public static Payment register(Order order, Long priceSnap, PaymentStatus status, LocalDateTime paymentAt, LocalDateTime refundAt) {
+    public static Payment register(Order order, Long priceSnap) {
         Payment payment = new Payment();
         payment.order = order;
         payment.portOneId = String.format(
@@ -55,9 +55,9 @@ public class Payment extends Base {
                 , UUID.randomUUID().toString().replace("-", "").substring(0, 12)
         );
         payment.priceSnap = priceSnap;
-        payment.status = status;
-        payment.paymentAt = paymentAt;
-        payment.refundAt = refundAt;
+        payment.status = PaymentStatus.PENDING;
+        payment.paymentAt = LocalDateTime.now();
+        payment.refundAt = null;
         payment.deleted = false;
         return payment;
     }

--- a/src/main/java/com/bootcamp/paymentdemo/domain/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/bootcamp/paymentdemo/domain/payment/repository/PaymentRepository.java
@@ -1,0 +1,20 @@
+package com.bootcamp.paymentdemo.domain.payment.repository;
+
+import com.bootcamp.paymentdemo.domain.order.entity.Order;
+import com.bootcamp.paymentdemo.domain.payment.entity.Payment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
+
+public interface PaymentRepository extends JpaRepository<Payment, Long> {
+    @Query("""
+            SELECT p
+            FROM Payment p
+            JOIN FETCH Order o
+            WHERE p.deleted = false
+            AND p.status = "PENDING"
+            AND o.orderId = :orderId
+          """)
+    Optional<Payment> findByOrderId(Long orderId);
+}

--- a/src/main/java/com/bootcamp/paymentdemo/domain/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/bootcamp/paymentdemo/domain/payment/repository/PaymentRepository.java
@@ -11,9 +11,9 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
     @Query("""
             SELECT p
             FROM Payment p
-            JOIN FETCH Order o
+            JOIN FETCH p.order o
             WHERE p.deleted = false
-            AND p.status = "PENDING"
+            AND p.status = 'PENDING'
             AND o.orderId = :orderId
           """)
     Optional<Payment> findByOrderId(Long orderId);

--- a/src/main/java/com/bootcamp/paymentdemo/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/bootcamp/paymentdemo/domain/payment/service/PaymentService.java
@@ -1,0 +1,54 @@
+package com.bootcamp.paymentdemo.domain.payment.service;
+
+import com.bootcamp.paymentdemo.common.exception.ServiceErrorException;
+import com.bootcamp.paymentdemo.domain.order.entity.Order;
+import com.bootcamp.paymentdemo.domain.order.repository.OrderRepository;
+import com.bootcamp.paymentdemo.domain.payment.dto.CreatePaymentRequest;
+import com.bootcamp.paymentdemo.domain.payment.dto.CreatePaymentResponse;
+import com.bootcamp.paymentdemo.domain.payment.entity.Payment;
+import com.bootcamp.paymentdemo.domain.payment.repository.PaymentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+import static com.bootcamp.paymentdemo.common.exception.ErrorEnum.ERR_NOT_FOUND_ORDER;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentService {
+    private final PaymentRepository paymentRepository;
+    private final OrderRepository orderRepository;
+
+    // TODO 결제는 포인트 사상 제외, 왠만하면 주문에서 처리하는 것으로, 안되면 로직 수정 필요
+    @Transactional
+    public CreatePaymentResponse createPayment(CreatePaymentRequest request) {
+        Order order = orderRepository.findById(Long.valueOf(request.getOrderId())).orElseThrow(
+                () -> new ServiceErrorException(ERR_NOT_FOUND_ORDER)
+        );
+
+        Payment payment = Payment.register(
+                order
+                , (long) request.getTotalAmount()
+        );
+
+        // 기존 주문 건이 있을 경우 (결제 창 닫아 취소 했을 경우 해당 주문 건 재활용)
+        Optional<Payment> setPayment = paymentRepository.findByOrderId(Long.valueOf(request.getOrderId()));
+        if(setPayment.isPresent()) {
+            Payment existingPayment = setPayment.get();
+            return CreatePaymentResponse.register(
+                    true
+                    , existingPayment.getPortOneId()
+                    , existingPayment.getStatus().name()
+            );
+        } else {
+            Payment savedPayment = paymentRepository.save(payment);
+            return CreatePaymentResponse.register(
+                    true
+                    , savedPayment.getPortOneId()
+                    , savedPayment.getStatus().name()
+            );
+        }
+    }
+}

--- a/src/main/java/com/bootcamp/paymentdemo/domain/product/controller/ProductController.java
+++ b/src/main/java/com/bootcamp/paymentdemo/domain/product/controller/ProductController.java
@@ -1,0 +1,26 @@
+package com.bootcamp.paymentdemo.domain.product.controller;
+
+import com.bootcamp.paymentdemo.domain.product.dto.SearchProductResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class ProductController {
+    @GetMapping("/api/products")
+    public ResponseEntity<List<SearchProductResponse>> getProducts() {
+        return ResponseEntity.status(HttpStatus.OK).body(List.of(
+                new SearchProductResponse(
+                        "PROD-TESTUUID"
+                        , "테스트 상품"
+                        , 1000L
+                        , 100L
+                )
+        ));
+    }
+}

--- a/src/main/java/com/bootcamp/paymentdemo/domain/product/dto/SearchProductResponse.java
+++ b/src/main/java/com/bootcamp/paymentdemo/domain/product/dto/SearchProductResponse.java
@@ -1,0 +1,9 @@
+package com.bootcamp.paymentdemo.domain.product.dto;
+
+public record SearchProductResponse(
+        String id
+        , String name
+        , Long price
+        , Long stock
+) {
+}

--- a/src/main/java/com/bootcamp/paymentdemo/domain/product/entity/Product.java
+++ b/src/main/java/com/bootcamp/paymentdemo/domain/product/entity/Product.java
@@ -17,6 +17,8 @@ public class Product extends Base {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long productId;
 
+    private String productUid;
+
     @Column(nullable = false, length = 100)
     private String name;
 

--- a/src/main/resources/client-api-config.yml
+++ b/src/main/resources/client-api-config.yml
@@ -28,8 +28,8 @@ api:
     # 인증 (Authentication)
     # ========================================
     login:
-      url:
-      method:
+      url: /api/auth/login
+      method: POST
       description: 사용자 로그인
       request:
         fields:
@@ -88,8 +88,8 @@ api:
               description: 에러 메시지 (실패 시)
 
     get-current-user:
-      url:
-      method:
+      url: /api/users
+      method: GET
       description: 현재 로그인한 사용자 정보 조회
       response:
         body:
@@ -123,8 +123,8 @@ api:
     # 상품 & 주문 (Product & Order)
     # ========================================
     list-products:
-      url:
-      method:
+      url: /api/products
+      method: GET
       description: 상품 목록 조회
       response:
         body:
@@ -148,8 +148,8 @@ api:
               description: 재고 수량
 
     create-order:
-      url:
-      method:
+      url: /api/orders
+      method: POST
       description: 주문 생성 (총 금액은 서버에서 계산)
       request:
         fields:
@@ -175,8 +175,8 @@ api:
               description: 생성된 주문 번호
 
     list-orders:
-      url:
-      method:
+      url: /api/orders
+      method: GET
       description: 주문 목록 조회 (현재 로그인한 사용자의 주문)
       response:
         body:
@@ -223,8 +223,8 @@ api:
     # 결제 (Payment)
     # ========================================
     create-payment:
-      url:
-      method:
+      url: /api/payments
+      method: POST
       description: 결제 시작 요청 (DB에 PENDING 상태로 등록, PortOne SDK 호출 전에 먼저 호출)
       request:
         fields:
@@ -257,7 +257,7 @@ api:
               description: 결제 상태 (PENDING)
 
     confirm-payment:
-      url:
+      url: /api/payments/{paymentId}/confirm
       method:
       description: 결제 확정 (PortOne 결제 검증 및 주문 상태 업데이트)
       pathParams:


### PR DESCRIPTION
# Work History
- 결제 창 까지 로드 되도록 구현


결제 창을 띄우고 나서 취소할 경우, 
해당 결제건을 다시 결제 할 때 해당 건을 다시 결제 할 수 있도록 구현

# Releated Issue
Closes #23 

# CheckList
- [x] Commit Convention 준수 여부 확인
- [x] 코드에 대해서 주석 작성 여부 확인
- [x] 불필요 주석, import, Test Log 삭제 여부 확인

# ETC
해당 구현점은 앞단이 좀 완성이 되어 있어야 해서 임시로 API를 집어 넣은 부분이 있으니 유의
Order Entity 1대1 매칭 되도록 수정 사항 있음
- 결제 창 불러오기
<img width="1173" height="931" alt="image" src="https://github.com/user-attachments/assets/b77370cf-2fbf-437a-ae0a-0dd05662547e" />

- 결제와 동시에 생성된 Payment 데이터
<img width="1658" height="81" alt="image" src="https://github.com/user-attachments/assets/54b2ac60-2341-4358-ac5d-ad66c1b16caa" />
